### PR TITLE
Fix #245 - Add missing Korean translaiton strings

### DIFF
--- a/webapp/src/main/resources/i18n/contrast-finder_utf8_ko.properties
+++ b/webapp/src/main/resources/i18n/contrast-finder_utf8_ko.properties
@@ -1,221 +1,216 @@
 ###### i18n file in UTF-8 character encoding  #######################
 NOT_A_VALID_COLOR=색은 #000000부터 #FFFFFF 사이에 있는 값을 입력하셔야 합니다
-NOT_A_VALID_RATIO.colorModel.ratio=올바르지 않은 비율
-home.titleTag=Contrast Finder, 웹 접근성 기준(WCAG)에 적합한 충분히 대비되는 색의 조합 검색
+NOT_A_VALID_RATIO.colorModel.ratio=올바르지 않은 명암비
+home.titleTag=Contrast Finder, 웹 접근성 기준(WCAG)에 적합하도록 명암이 충분히 대비되는 색의 조합 검색
 ###### 330 characters max for "home.metaDescription"
-home.metaDescription=Contrast-Finder는 웹 접근성 기준(WCAG)에 적합한 충분히 대비되는 색의 조합을 찾아줍니다. \
-  그래서 색의 대비와 관련된 웹 접근성(a11y) 테스트를 충족시키는 데 도움을 드립니다. \
+home.metaDescription=Contrast-Finder는 웹 접근성 기준(WCAG)에 적합하도록 명암이 충분히 대비되는 색의 조합을 찾아줍니다. \
+  그래서 색의 명암비와 관련된 웹 접근성(a11y) 테스트를 충족시키는 데 도움을 드립니다. \
   Contrast-Finder는 웹디자이너, 웹 개발자 혹은 웹 접근성 전문가가 \
   HTML 페이지와 웹사이트의 가독성을 개선하는 데 사용할 수 있도록 디자인되었습니다.
 logo.link.title=홈페이지로 되돌아 가기
 nav.language=한국어
 nav.language-switching=한국어로 전환
 nav.language-switching.aria-label=언어
-result.title.colors=대비 색
+result.title.colors=색 조합
 result.title.foregroundColor=본문 글자
 result.title.backgroundColor=배경
-result.title.minRation=최소 비율
+result.title.minRation=최소 명암비
 form.fillInFields=다음 항목을 채워주십시오:
-form.description=<span lang="en">Contrast-Finder</span>는 웹 접근성 기준에 적합한 충분히 대비되는 색의 조합을 찾아줍니다
-form.help=16진법, RGB 혹은 CSS 컬러 키워드 형태로 된 색의 값을 입력하실 수 있습니다. <br> \
+form.description=<span lang="en">Contrast-Finder</span>는 웹 접근성 기준에 적합하도록 명암이 충분히 대비되는 색의 조합을 찾아줍니다
+form.help=색의 값으로 16진법, RGB 혹은 CSS 컬러 키워드 형태의 값을 입력하실 수 있습니다. <br> \
           보기: <code>#FFFFFF</code>, <code>rgb(255,255,255)</code> 혹은 <code>white</code>
-form.foregroundColor=본문 글자 색
-form.backgroundColor=배경 색
+form.foregroundColor=본문 글자색
+form.backgroundColor=배경색
 form.component=교정하려는 색
-form.componentForeground=본문 글자 색을 교정
-form.componentBackground=배경 색을 교정
-form.ratio=최소 비율
-#form.currentRatio=Current ratio:
-#form.currentRatio.alt.valid=The contrast of your colours is sufficient.
-#form.currentRatio.alt.fail=The contrast of your colours is insufficient.
-form.contrastOld=원래의 색 대비
-form.contrastNew=새로운 색 대비
+form.componentForeground=본문 글자색 교정
+form.componentBackground=배경색 교정
+form.ratio=최소 명암비
+form.currentRatio=현재 명암비:
+form.currentRatio.alt.valid=선택하신 색상의 명암비가 충분합니다.
+form.currentRatio.alt.fail=선택하신 색상의 명암비가 충분하지 않습니다.
+form.contrastOld=원래의 명암비
+form.contrastNew=새로운 명암비
 form.validate=기준에 적합한 색 검색하기
-form.validContrast=기준에 적합한 색 대비:
+form.validContrast=기준에 적합한 명암비:
 form.validContrastDesc=선택한 색의 조합은 이미 괜찮습니다
 ##### For [form.resultNumber]
 ##### ---> Do not translate "choice", it is an internal ID
 form.resultNumber={0} {0,choice,1#개의 결과|1<개의 결과}
-form.contrastSolutionCaption=기준에 적합한 색 대비
+form.contrastSolutionCaption=기준에 적합한 명암비
 form.contrastSolutionForeground=본문
 form.contrastSolutionBackground=배경
-form.contrastSolutionRatio=비율
+form.contrastSolutionRatio=명암비
 form.contrastSolutionSample=표본
-form.initialContrastCaption=기준에 부적합한 색 대비
-form.sampleTitle=큰 크기의 제목과
-form.sampleTitleBold=크고 좀 더 굵은 글자
+form.initialContrastCaption=부적합한 명암비
+form.sampleTitle=커다란 크기의 제목과
+form.sampleTitleBold=크고 좀 더 두꺼운 글자
 form.sampleText=여기엔 약간의 예시 글과 함께
-form.sampleTextBold=더 굵은 글자가 함께 표시되면서
-form.sampleText2=\ 색의 대비 정도를 확인하실 수 있습니다.
+form.sampleTextBold=두꺼운 글자가 함께 표시되면서
+form.sampleText2=\ 색의 명암비를 직접 확인하실 수 있습니다.
 form.sc-info=<a hreflang="en" href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"> \
                 <abbr lang="en" title="Web Content Accessibility Guidelines">WCAG</abbr> \
                 통과 기준 1.4.3 \
             </a>에 의하면 \
             글자는 최소 <strong>4.5</strong> (큰 글자의 경우 <strong>3</strong>) \
-            이상의 대비 비율을 가지고 있어야 합니다.
+            이상의 명암비를 가지고 있어야 합니다.
 footer.LikedCf=<em lang="en">Contrast-Finder</em>가 마음에 드셨나요? <br>그럼 <strong>Asqatasun</strong>도 방문해 보세요. <a hreflang="en" href="https://app.asqatasun.org/">웹 접근성을 고려한 오픈소스 웹 사이트 분석 도구</a>입니다.
 form.contrastSolutionDistance=편차
 form.contrastSolutionDistanceEx=처음 지정한 색과의 편차
 form.objectifs=검색 범위
-form.algoHSV= 확장된 색 범위 속 기준에 적합한 대비 색
-form.algoRGB=처음 지정한 색과 아주 비슷하면서도 기준에 적합한 대비 색
-form.invalidColor=올바르지 않은 색
+form.algoHSV= 기준에 적합한 명암비를 가지고 있는 색
+form.algoRGB=처음 지정한 색과 아주 비슷하면서도 기준에 적합한 명암비를 가지고 있는 색
+form.invalidColor=부적합한 색
 form.changeComponent=교정 색의 조건을 다음과 같이 바꿔서 다시 시도해 봅시다. &rarr;
 form.invalidAlgo=알고리듬값이 올바르지 않습니다.
-form.tryHsv=좀 더 <em>넓은 색 범위</em> 안에서 대비 색 찾아보기
-form.tryRgb=처음 지정한 색과 <em>아주 비슷</em>하면서도 기준에 적합한 대비 색 찾아보기
-form.testedColors=개의 색이 검토됨
+form.tryHsv=좀 더 <em>넓은 범위</em>의 기준에 적합한 명암비를 가진 색 찾아보기
+form.tryRgb=처음 지정한 색과 <em>아주 비슷</em>하면서도 기준에 적합한 명암비를 가진 색 찾아보기
+form.testedColors=개의 색상이 검토됨
 form.notSatisfied=만족스럽지 않으세요?
 form.anyResult=그럼
-form.oppositeComponentForeground=배경 색
-form.oppositeComponentBackground=본문 글자 색
+form.oppositeComponentForeground=배경색
+form.oppositeComponentBackground=본문 글자색
 message.addon=저기요! 혹시 저희 <a class="alert-link" href="{0}"><em>Contrast-Finder</em> Firefox 부가 기능</a>을 써보셨나요?
 footer.poweredBy=운용 기술:
 footer.availableUnder=사용 권한:
 footer.link-twitter=트위터에서 Contrast-Finder 팔로우하기
 footer.link-git=GitHub에 있는 Contrast-Finder에 기여하기
-nav.link.pageAbout=<em lang="en">Contrast-Finder</em> 정보
-# page.result-error.titleTag=Error
-page.about.titleTag=Contrast-Finder 정보
-page.about.title=<em lang="en">Contrast-Finder</em> 정보
-page.about.metaDescription=Contrast-Finder는 두 가지 색(배경 색, 본문 글자 색)의 대비를 계산해서 \
-     색 대비가 충분한지 알려주는 도구입니다. \
-     색 대비가 충분하지 않다면, 몇 가지 충분히 대비되는 색의 조합을 제안해 드리는 것이 주요 목적입니다. 
-page.about.text=<em lang="en">Contrast-Finder</em>는 두 가지 색(배경 색, 본문 글자 색)의 대비를 계산해서 \
-     색 대비가 충분한지 알려주는 도구입니다. \
-     색 대비가 충분하지 않다면, 몇 가지 충분히 대비되는 색의 조합을 제안해 드리는 것이 주요 목적입니다. 
-page.about.links=You will find more information in english on the project website:<ul> \
+nav.link.pageAbout=<em lang="en">Contrast-Finder</em>에 관하여
+page.result-error.titleTag=오류
+page.about.titleTag=Contrast-Finder에 관하여
+page.about.title=<em lang="en">Contrast-Finder</em>에 관하여
+page.about.metaDescription=Contrast-Finder는 두 가지 색(배경색, 본문 글자색)의 명암비를 계산해서 \
+     명암비가 기준에 적합한지 알려주는 도구입니다. \
+     명암비가 충분하지 않다면, 충분한 명암비를 가진 색의 조합을 제안해 드리는 것이 주요 목적입니다.
+page.about.text=<em lang="en">Contrast-Finder</em>는 두 가지 색(배경 색, 본문 글자 색)의 명암비를 계산해서 \
+     명암비가 기준에 적합한지 알려주는 도구입니다. \
+     명암비가 충분하지 않다면, 충분한 명암비를 가진 색의 조합을 제안해 드리는 것이 주요 목적입니다.
+page.about.links=더 자세한 정보는 영문으로 된 프로젝트 웹사이트에서 확인하실 수 있습니다.:<ul> \
 <li lang="en"> <a hreflang="en" href="https://contrast-finder.org/#contrast-finder-about">What is <em>Contrast-Finder</em>?</a></li> \
 <li lang="en"> <a hreflang="en" href="https://contrast-finder.org/#contrast-finder-feedback">User Feedback</a></li> \
 <li lang="en"> <a hreflang="en" href="https://contrast-finder.org/#contrast-finder-contributing">Contributing</a></li> \
 <li lang="en"> <a hreflang="en" href="https://contrast-finder.org/#contrast-finder-history">History</a></li> \
 </ul>
-# page.about.fileList.title=Additional files
-# page.about.build.title=Build info
-# page.about.build.version=version:
-# page.about.build.gitBranch=git branch:
-# page.about.build.gitCommit=git commit:
-# page.about.build.build=Build:
-# page.about.build.date=date:
-# page.about.build.id=ID:
-# page.about.build.platform=Platform:
-# page.about.availableLanguages=Available languages
+page.about.fileList.title=추가 파일
+page.about.build.title=빌드 정보
+page.about.build.version=버전:
+page.about.build.gitBranch=깃 브랜치:
+page.about.build.gitCommit=깃 커밋:
+page.about.build.build=빌드:
+page.about.build.date=날짜:
+page.about.build.id=ID:
+page.about.build.platform=플랫폼:
+page.about.availableLanguages=사용 가능한 언어
 info.about.title=<em lang="en">Contrast Finder</em>가 무엇인가요?
-info.about=<p>  \
-    <em lang="en">Contrast-Finder</em>는 두 가지 색(배경 색, 본문 글자 색)의 대비를 계산해서 \
-     색 대비가 충분한지 알려주는 도구입니다. \
-     색 대비가 충분하지 않다면, 몇 가지 충분히 대비되는 색의 조합을 제안해 드리는 것이 주요 목적입니다. \
+info.about=<p> \
+     <em lang="en">Contrast-Finder</em>는 두 가지 색(배경 색, 본문 글자 색)의 명암비를 계산해서 \
+     명암비가 기준에 적합한지 알려주는 도구입니다. \
+     명암비가 충분하지 않다면, 충분한 명암비를 가진 색의 조합을 제안해 드리는 것이 주요 목적입니다. \
 </p> \
 <p> <strong lang="en">Contrast-Finder</strong>는 웹디자이너, 웹 개발자 혹은 웹 접근성 전문가가 \
     HTML 페이지와 웹사이트의 가독성을 개선하는 데 사용할 수 있도록 디자인되었습니다. \
 </p>
 info.feedback.title=사용자 건의
-info.feedback=<p><em lang="en">Contrast-Finder</em>를 사용하시면서 문제가 있거나 다른 문의 사항이 있으시면, 아래에 있는 통로로 연락해주시기 바랍니다: </p> \
-<ul> \
+info.feedback=<p>\
+  <em lang="en">Contrast-Finder</em>를 사용하시면서 문제가 있거나 다른 문의 사항이 있으시면, 아래에 있는 통로로 연락해주시기 바랍니다: \
+</p>\
+<ul>\
     <li> <a href="https://forum.asqatasun.org/c/contrast-finder">Asqatasun 포럼</a>    </li> \
     <li> <a title="Contrast-Finder의 트위터 계정" href="https://twitter.com/contrast_finder">트위터 @Contrast_Finder</a> </li> \
     <li> <a href="https://github.com/Asqatasun/Contrast-Finder"><span lang="en">Contrast-Finder</span>의 Github 저장소</a> </li> \
 </ul>
 info.contribute.title=<em lang="en">Contrast-Finder</em>의 기능 개선 및 제안
 info.contribute=<p> \
-    어떠한 제안이든 모두 환영합니다!  \
+    어떠한 제안이든 언제나 환영합니다!  \
     번역, 문제 수정, 오류 보고, 새로운 기능… <br> \
     부담없이 \
-        <a hreflang="en" href="https://github.com/Asqatasun/Contrast-Finder/blob/develop/CONTRIBUTING.md">소스 코드</a>를 가지고 놀아보시고, \
-    <a href="https://forum.Asqatasun.org/">포럼</a>에서도 상의해 보세요. \
+        <a hreflang="en" href="https://github.com/Asqatasun/Contrast-Finder/blob/develop/CONTRIBUTING.md">소스 코드</a>를 가지고 실험해 보시고, \
+    <a href="https://forum.Asqatasun.org/">포럼</a>에서 상의해 보세요. \
 </p>
 help.title=도움말 / 이 도구는 어떻게 사용하나요?
 help.head=<p> <strong lang="en">Contrast-Finder</strong> 인터페이스 양식에는 다섯 개의 필수 입력 항목이 있습니다.  </p> \
 <ul> \
-    <li> <a href="#user-help_text-color">본문 글자 색</a> </li> \
-    <li> <a href="#user-help_background-color">배경 색</a> </li> \
-    <li> <a href="#user-help_minimum-ratio">최소 비율</a> </li> \
+    <li> <a href="#user-help_text-color">본문 글자색</a> </li> \
+    <li> <a href="#user-help_background-color">배경색</a> </li> \
+    <li> <a href="#user-help_minimum-ratio">최소 명암비</a> </li> \
     <li> <a href="#user-help_color-to-edit">교정하려는 색</a> </li> \
     <li> <a href="#user-help_gimme-algorithms">검색 범위</a> </li> \
 </ul>
-help.txt-color.title=
-help.txt-color=
-help.bg-color.title=
-help.bg-color=
-help.color-to-edit.title=교정하려는 색
-help.color-to-edit=<p> \
-   본문 글자 색 또는 배경색을 선택하실 수 있습니다. 기본은 본문 글자 색.\
-</p> \
-<p> 선택하신 색은 나중에 기준에 적합한 색을 찾을 때까지 수정됩니다. \
-    그리고 나머지 색은 바뀌지 않습니다. \
-</p>
-help.algo.title=검색 범위 / 알고리듬
-help.algo=<h4>“처음 지정한 색과 아주 비슷하면서도 기준에 적합한 대비 색”</h4> \
-<p> \
-    이것이 기본으로 쓰이는 알고리듬입니다. \
-    처음 지정한 색과 아주 가까운 색만 골라서 보여줍니다. \
-    (색의 편차는 수학적 방식으로 산출되며, 디자이너의 관점과는 다를 수 있습니다.) \
-</p> \
-<p> \
-    몇몇 색 조합에 따라선, 알고리듬은 아무런 결과도 추출하지 못할 수 있습니다 ; \
-    이 경우엔, 다른 알고리듬을 사용해 보십시오. \
-</p> \
-<h4>“확장된 색 범위 속 기준에 적합한 대비 색”</h4> \
-<p> \
-    차선책으로 쓰이는 알고리듬으로, 첫 번째 것이 아무런 결과도 보여주지 않을 때 사용합니다. \
-    하지만, 산출되는 색은 최초 지정 색과 (많이) 다를 수 있습니다. \
-</p>
-help.ratio.title=본문 글자 색
-##################################################################################
-# "help.ratio" will certainly evolve.
-# ----> See issue #136 "Text size understanding : comments on pt => px conversion"
-#       https://github.com/Asqatasun/Contrast-Finder/issues/136
-##################################################################################
-help.ratio=<p> \
-    본문에 쓰인 <strong>글자</strong>에 입히는 <strong>색</strong>입니다. \
-    이 항목에는 <em>CSS 컬러 키워드</em>, <em>16진법</em>, 혹은 \
-    <em><abbr lang="en" title="Red Green Blue">RGB</abbr></em> 값을 입력하실 수 있습니다. \
-    실제 변환된 색은 항목 오른쪽에서 미리 확인하실 수 있습니다. \
+help.txt-color.title=본문 글자색
+help.txt-color=<p> \
+    본문에 쓰인 <strong>글자</strong>에 칠하는 <strong>색</strong>입니다. \
+    이 항목에는 <em>CSS 컬러 키워드</em>, <em>16진법</em> 형태의 컬러 값, \
+    혹은 <em><abbr lang="en" title="Red Green Blue">RGB</abbr></em> 컬러 값을 입력하실 수 있습니다. \
+    입련된 값은 항목 오른쪽에서 실제 변환된 색으로 확인하실 수 있습니다. \
 </p> \
 <h4>컬러 <strong>키워드</strong> </h4> \
-<p> 보기: <code>Black</code>, <code>Silver</code>, <code>YellowGreen</code>, <code>MediumPurple</code>. <br> \
+<p> 예시: <code>Black</code>, <code>Silver</code>, <code>YellowGreen</code>, <code>MediumPurple</code>. <br> \
     여기에 사용할 수 있는 값은 \
     <a hreflang="en" href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Color_keywords">CSS 컬러 키워드</a> 문서에 나열되어 있습니다. \
     (<em>CSS level 1</em>부터 <em>CSS level 4</em>까지). \
 </p> \
 <h4><strong>16진법</strong> 형태의 컬러 값</h4> \
-<p> 보기: <code>#AABBCC</code>.  \
+<p> 예시: <code>#AABBCC</code>.  \
     참고로 <code>#ABC</code>처럼 간략한 형태로 입력하셔도 되고, \
     해당 항목은 자동으로 <code>#AABBCC</code>로 변환됩니다. \
-    또, 여기엔 <code>#</code> 글자를 생략하고 입력하셔도 돼서, \
+    또한, 여기엔 <code>#</code> 글자를 생략하고 입력하셔도 돼며, \
     <code>FFF</code> 혹은 <code>FFFFFF</code> 모두 혼용해서 입력하실 수 있습니다. \
 </p> \
 <h4><strong>RGB</strong> 형태의 컬러 값</h4> \
-<p> 보기: <code>rgb(255,255,255)</code>. <br> \
+<p> 예시: <code>rgb(255,255,255)</code>. <br> \
     마찮가지로 <code>255,255,255</code>처럼 짧은 용법으로 입력하실 수 있으며, \
     그러면 <code>rgb(255,255,255)</code>로 해석됩니다.  \
-</p> \
-<h3 id="user-help_background-color">배경색</h3> \
-<p> \
+</p>
+help.bg-color.title=배경색
+help.bg-color=<p> \
     <strong>배경</strong>에 칠해지는 색입니다. <br> \
-    이 항목은 앞의 본문 글자 색 항목과 같은 원리로 작동합니다.\
+    이 항목은 본문 글자색 항목과 같은 원리로 작동합니다.\
+</p>
+help.color-to-edit.title=교정하려는 색
+help.color-to-edit=<p> 본문 글자색 또는 배경색을 선택하실 수 있습니다. 기본은 본문 글자색. </p> \
+<p> 선택하신 색은 나중에 기준에 적합한 색을 찾을 때까지 수정됩니다. \
+    하지만 나머지 색은 바뀌지 않습니다. </p>
+help.algo.title=검색 범위 / 알고리듬
+help.algo=<h4>“처음 지정한 색과 아주 비슷하면서도 기준에 적합한 명암비를 가진 색”</h4> \
+<p> \
+    이것이 기본으로 쓰이는 알고리듬입니다. \
+    처음 지정한 색에 아주 가까운 색의 옵션을 제공합니다. \
+    (색의 편차는 수학적 기준으로 산출되며, 디자이너의 관점과는 다를 수 있습니다.) \
 </p> \
-<h3 id="user-help_minimum-ratio">최소 <em>비율</em></h3>\
-<p> 세 가지 선택가능한 값으로 <strong>3</strong>, <strong>4.5</strong> 그리고 <strong>7</strong>이 있습니다. </p> \
-<p> 비율은 어떻게 정할까요? 다음의 요소에 따라 결정됩니다: </p> \
+<p> \
+    몇몇 색 조합에 따라선, 알고리듬이 아무런 결과도 추출하지 못할 수도 있습니다 ; \
+    이 경우엔, 다른 알고리듬을 사용해 보십시오. \
+</p> \
+<h4>“기준에 적합한 명암비를 가지고 있는 색”</h4> \
+<p> \
+    차선책으로 쓰이는 알고리듬으로, 첫 번째 것이 아무런 결과도 보여주지 않을 때 사용합니다. \
+    하지만, 산출된 색의 옵션은 최초 지정 색과 (많이) 다를 수 있습니다. \
+</p>
+help.ratio.title=최소 <em>명암비</em>
+##################################################################################
+# "help.ratio" will certainly evolve.
+# ----> See issue #136 "Text size understanding : comments on pt => px conversion"
+#       https://github.com/Asqatasun/Contrast-Finder/issues/136
+##################################################################################
+help.ratio=<p> 세 가지 선택 가능한 값으로 <strong>3</strong>, <strong>4.5</strong> 그리고 <strong>7</strong>이 있습니다. </p>\
+<p> 명암비는 어떻게 정할까요? 다음의 요소에 따라 결정됩니다: </p>\
 <ul> \
     <li> 접근성 요구 수준: <strong>AA</strong> 또는 <strong>AAA</strong>. </li> \
     <li> 글자의 크기. </li> \
     <li> 글자가 볼드체인지 아닌지? </li> \
 </ul> \
 <h4> 레벨 <em>AA</em> </h4> \
-<p> 두 가지 요소(크기와 볼드 유무)에 따라 다음과 같은 네 가지 조합을 도출할 수 있습니다: </p> \
+<p> 두 가지 요소(크기와 볼드체 유무)에 따라 다음과 같은 네 가지 조합을 도출할 수 있습니다: </p> \
 <ul> \
-    <li> 볼드체가 아닌 글자 + 글자 크기 &lt; <code>24px</code>: 비율 = <strong>4.5</strong> </li> \
-    <li> 볼드체가 아닌 글자 + 글자 크기 &gt; <code>24px</code>: 비율 = <strong>3</strong> </li> \
-    <li> 볼드체 글자 + 글자 크기 &lt; <code>19px</code>: 비율 = <strong>4.5</strong> </li> \
-    <li> 볼드체 글자 + 글자 크기 &gt; <code>19px</code>: 비율 = <strong>3</strong> </li> \
+    <li> 볼드체가 아닌 글자 + 글자 크기 &lt; <code>24px</code>: 명암비 = <strong>4.5</strong> </li> \
+    <li> 볼드체가 아닌 글자 + 글자 크기 &gt; <code>24px</code>: 명암비 = <strong>3</strong> </li> \
+    <li> 볼드체 글자 + 글자 크기 &lt; <code>19px</code>: 명암비 = <strong>4.5</strong> </li> \
+    <li> 볼드체 글자 + 글자 크기 &gt; <code>19px</code>: 명암비 = <strong>3</strong> </li> \
 </ul> \
 <h4> 레벨 <em>AAA</em> </h4> \
-<p> 레벨 <strong>AAA</strong>의 원리는 같으나, 비율만 다음과 같이 증가합니다: </p> \
+<p> 레벨 <strong>AAA</strong>의 원리는 같으나, 명암비만 다음과 같이 증가합니다: </p> \
 <ul> \
-    <li> <strong>4.5</strong> 비율은 <strong>7</strong>로 증가 </li> \
-    <li> <strong>3</strong> 비율은 <strong>4.5</strong>로 증가 </li> \
+    <li> <strong>4.5</strong> 명암비는 <strong>7</strong>로 증가 </li> \
+    <li> <strong>3</strong> 명암비는 <strong>4.5</strong>로 증가 </li> \
 </ul>  \
 <h4> 글자 크기의 이해 </h4> \
 <ul> \
@@ -224,21 +219,21 @@ help.ratio=<p> \
     <li> <code>24px</code> 정도의 크기는 <code>18pt</code> 또는 \
          <code>150%</code> 혹은 <code>1.5em</code> 크기와 같은 것으로 칩니다. </li> \
 </ul>  \
-<p> \
-    글자 크기를 해석하는 방식에 관해서 더 깊고 자세히 알고 싶으시면, \
-    <a hreflang="en" href="https://www.w3.org/TR/WCAG20/#larger-scaledef">WCAG에 기술된 large-scale text의 정의</a>를 읽어보십시오.  \
-</p> \
-<h4> 대비 비율에 관한 자세한 설명 </h4> \
-<ul> \
-    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast">WCAG 2.0 통과 기준 1.4.3</a> (레벨 AA)</li> \
-    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7">WCAG 2.0 통과 기준 1.4.6</a> (레벨 AAA)</li> \
-    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/#contrast-ratiodef">WCAG 2.0 용어 해설 - 대비 비율</a></li> \
-    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/relative-luminance.xml">WCAG 2.0 - MathML 버전의 상대 휘도 정의</a></li> \
+<p> 글자 크기를 해석하는 방식에 관해서 더 깊고 자세히 알고 싶으시면, \
+    <a hreflang="en" href="https://www.w3.org/TR/WCAG20/#larger-scaledef">WCAG에 기술된 large-scale text의 정의</a>를 읽어보십시오.  </p> \
+<h4> 명암비에 관한 자세한 설명 </h4> \
+<ul>\
+    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/#contrast-ratiodef">WCAG 2.0 용어집 - 명암비</a></li>\
+    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast">WCAG 2.0 - 명암비 (최소): 통과 기준 1.4.3</a> (레벨 AA)</li>\
+    <li><a hreflang="en" href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html">WCAG 2.0 - 명암비 (최소): 통과 기준 1.4.3 이해하기</a></li>\
+    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7">WCAG 2.0 - 명암비 (확장): 통과 기준 1.4.6</a> (레벨 AAA)</li>\
+    <li><a hreflang="en" href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast7.html">WCAG 2.0 - 명암비 (확장): 통과 기준 1.4.6 이해하기</a></li>\
+    <li><a hreflang="en" href="https://www.w3.org/TR/WCAG20/relative-luminance.xml">WCAG 2.0 - MathML 버전의 상대 휘도 정의</a></li>\
 </ul>
-#########  unused i18n entries
+#########  unused i18n entries ##############################################
 # form.results=개의 결과
 # form.usage=사용:
 # form.ratioMedium=작은 글자 (크기 &lt; 18px, 레벨 AA)
 # form.ratioShort=큰 글자 (크기 &ge; 18px, 레벨 AA)
-# form.ratioHigh=대비의 정도 키우기 (레벨 AAA)
-# form.description_v2=지정한 두 가지 색을 가지고, 웹 접근성 기준에 적합한, 충분히 대비되는 색의 조합을 찾아주세요:
+# form.ratioHigh=명암비 강화 (레벨 AAA)
+# form.description_v2=지정한 두 가지 색을 가지고, 웹 접근성 기준에 적합한, 충분한 명암비를 가진 색의 조합을 찾아주세요:


### PR DESCRIPTION
Added missing translations and corrected some expressions to be read more naturally.

## I verified my work is based on `develop` branch
* [x] yes, keep going

## Purpose of this Pull Request?
To update Korean translation strings to match with the latest English translation file.

## Where should the reviewer start its review?
 /webapp/src/main/resources/i18n/contrast-finder_utf8_ko.properties

## Any background context you want to provide?
Some of the misplaced Korean strings also corrected.
Ex. All of help.txt-color strings were misplaced at the beginning of help.ratio property section.

## What are the related issues?
Issue #245
